### PR TITLE
Addition of fadeZoom and zoom transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It can then be used on a transition. Example for fade and left slide animation, 
 Example for fade and zoom animation with a 5% offset:
 ```elm
   div
-    [ style (TransitStyle.fadeZoom 0.5 model.transition) ]
+    [ style (TransitStyle.fadeZoom 0.05 model.transition) ]
     [ text "Some content" ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 HTML animations for [elm-transit](http://package.elm-lang.org/packages/etaque/elm-transit/latest)'s `Transition`, to be used on elm-html `style` attribute. At the moment we have those, though it's easy to add more:
 
 * `fade`
-* `slideLeft`
-* `fadeSlideLeft`
+* `slide`
+* `zoom`
+* `fadeSlide`
+* `fadeZoom`
 
 An ideal companion to [elm-transit-router](http://package.elm-lang.org/packages/etaque/elm-transit-router/latest).
 
@@ -30,7 +32,14 @@ It can then be used on a transition. Example for fade and left slide animation, 
 
 ```elm
   div
-    [ style (TransitStyle.fadeSlideLeft 100 model.transition) ]
+    [ style (TransitStyle.fadeSlide 100 model.transition) ]
+    [ text "Some content" ]
+```
+
+Example for fade and zoom animation with a 5% offset:
+```elm
+  div
+    [ style (TransitStyle.fadeZoom 0.5 model.transition) ]
     [ text "Some content" ]
 ```
 

--- a/src/TransitStyle.elm
+++ b/src/TransitStyle.elm
@@ -1,6 +1,7 @@
 module TransitStyle
     exposing
         ( fadeSlide
+        , fadeZoom
         , slide
         , slideOut
         , slideIn
@@ -8,6 +9,9 @@ module TransitStyle
         , fadeOut
         , fadeIn
         , compose
+        , zoom
+        , zoomIn
+        , zoomOut
         , Style
         )
 
@@ -17,14 +21,21 @@ module TransitStyle
       [ style (fadeSlide 100 model.transition) ]
       [ text "Some content" ]
 
+    div
+      [ style (fadeZoom 0.05 model.transition) ]
+      [ text "Some content" ]
+
 # Combinations
-@docs fadeSlide
+@docs fadeSlide, fadeZoom
 
 # Slide left
 @docs slide, slideOut, slideIn
 
 # Fade
 @docs fade, fadeOut, fadeIn
+
+# Zoom
+@docs zoom, zoomIn, zoomOut
 
 # Tooling to create animations
 @docs compose, Style
@@ -62,6 +73,13 @@ fadeSlide offset t =
     (slide offset t) ++ (fade t)
 
 
+{-| Combine fade and zoom with specified offset
+-}
+fadeZoom : Float -> Transition -> Style
+fadeZoom offset t =
+    ( zoom offset t ) ++ ( fade t )
+
+
 {-| Slide animation, with the specified offset.
 Greater than 0 to right, lesser to left.
 -}
@@ -86,6 +104,30 @@ slideIn offset v =
     (Ease.inCubic (1 - v))
         * offset
         |> translateX
+
+
+-- Zoom animations
+{-| Zoom animation
+-}
+zoom : Float -> Transition -> Style
+zoom offset =
+    compose ( zoomOut offset ) ( zoomIn offset )
+
+
+{-| Zoom in (enter)
+-}
+zoomIn : Float -> Float -> Style
+zoomIn offset v =
+    Ease.linear ( ( v * offset ) + ( 1 - offset ) )
+        |> scaleXY
+
+
+{-| Zoom out (exit)
+-}
+zoomOut : Float -> Float -> Style
+zoomOut offset v =
+    Ease.inCubic ( ( v * offset ) + ( 1 - offset ) )
+        |> scaleXY
 
 
 {-| Fade animation
@@ -128,3 +170,20 @@ translateX : Float -> Style
 translateX v =
     [ ( "transform", "translateX(" ++ toString v ++ "px)" )
     ]
+
+
+{-| Scale style
+-}
+scaleXY : Float -> Style
+scaleXY v =
+    let
+        target =
+            String.concat
+                [ "scale("
+                , toString v
+                , ","
+                , toString v
+                , ")"
+                ]
+    in
+        [ ( "transform", target ) ]


### PR DESCRIPTION
Hi there, I created a zoom (out then in) transition, as well as a fade/zoom combination for elm-transit-style. I think it could make a useful addition to this package!

Contains:
- Scale CSS style (X and Y combination)
- fadeZoom transition combination
- fade transition
- fadeIn and fadeOut helper functions
- Updated Readme

Example:
![elm-transit-style-zoom](https://cloud.githubusercontent.com/assets/3385296/21966214/414ab4b4-db24-11e6-88be-6c544496fea0.gif)
